### PR TITLE
Update CyberRT_Quick_Start.md

### DIFF
--- a/docs/cyber/CyberRT_Quick_Start.md
+++ b/docs/cyber/CyberRT_Quick_Start.md
@@ -19,7 +19,7 @@ couple of examples showing different functionalities of Cyber RT under the
 > **Note**: The examples need to run after successfully built within Apollo
 > Docker container.
 
-## Set up directry layout
+## Set up directory layout
 
 Take the sample component under `cyber/examples/common_component_example` for
 example:


### PR DESCRIPTION
Fix spelling of directory

## Summary by Sourcery

Documentation:
- Fix "directry" to "directory" in CyberRT_Quick_Start.md